### PR TITLE
Add new 40 character Australia Post connote

### DIFF
--- a/couriers/australia_post/index.js
+++ b/couriers/australia_post/index.js
@@ -15,7 +15,7 @@ function valid(connote) {
     return false;
   }
 
-  return [10, 14, 18, 21, 39].indexOf(connote.length) != -1;
+  return [10, 14, 18, 21, 39, 40].indexOf(connote.length) != -1;
 }
 
 module.exports = { courier_name, tracking_url, valid };

--- a/couriers/australia_post/index.test.js
+++ b/couriers/australia_post/index.test.js
@@ -9,6 +9,9 @@ describe("Australia Post", () => {
         expect(australia_post.valid("000000000000000000")).toBe(true); // 18
         expect(australia_post.valid("000000000000000000000")).toBe(true); // 21
         expect(
+          australia_post.valid("0199312650999998910001007263709006080997")
+        ).toBe(true); // 40
+        expect(
           australia_post.valid("000000000000000000000000000000000000000")
         ).toBe(true); // 39
       });


### PR DESCRIPTION
Australia Post Express Post connotes now have 40 character barcode